### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/aiw-devops/026fa017-a734-41d0-b35f-b437970587f0/bec28c10-2e06-44f5-b747-4a86bc9ba0ee/_apis/work/boardbadge/ff37d3ba-1cfd-459a-8ef5-49ac443616fd)](https://dev.azure.com/aiw-devops/026fa017-a734-41d0-b35f-b437970587f0/_boards/board/t/bec28c10-2e06-44f5-b747-4a86bc9ba0ee/Microsoft.RequirementCategory)
 # Contoso Traders
 
 ![Logo](./docs/images/logo-1280x640.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#2801. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.